### PR TITLE
トラッキングIDの一部のみを表示するように実装

### DIFF
--- a/views/posts.pug
+++ b/views/posts.pug
@@ -25,7 +25,8 @@ html(lang="jp")
             if isPostedByAdmin
               span #{post.id} : 管理人 ★
             else
-              span #{post.id} : ID:#{post.trackingCookie}      
+              - var originalTrackingId = post.trackingCookie ? post.trackingCookie.split('_')[0] : ''
+              span #{post.id} : ID:#{originalTrackingId}      
         div.card-body
           p.card-text(style="white-space:pre; overflow:auto;") #{post.content}
         div.card-footer


### PR DESCRIPTION
内部的にはハッシュ値が生成されているトラッキングIDの一部のみを表示させるように実装。
トラッキングIDの一部を取り出す処理を当初はif文の前に記述していたが、処理が必要になるのは投稿者が管理人ではないときに限定されているので、投稿者が管理人でない判定をした後のelse句以降に処理を記述した。
